### PR TITLE
Fix the d0u9/youtube-dl-webui build

### DIFF
--- a/dockerfiles/youtube-dl-webui/Dockerfile
+++ b/dockerfiles/youtube-dl-webui/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 		dirmngr \
 		wget \
 		xz-utils \
+                gpg \
 	' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \

--- a/dockerfiles/youtube-dl-webui/Dockerfile
+++ b/dockerfiles/youtube-dl-webui/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
 		dirmngr \
 		wget \
 		xz-utils \
-                gpg \
+		gpg \
 	' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \


### PR DESCRIPTION
Fixes the d0u9/youtube-dl-webui build by adding the "gpg" build dependency.

See https://hub.docker.com/r/d0u9/youtube-dl-webui/builds/bnsvckll644a7gnrdnm7avn/

[EDIT: might still be a little wonky - first DockerHub build failed, second worked (with no changes)](https://hub.docker.com/r/albinodrought/youtube-dl-web-ui/builds/)